### PR TITLE
Add v0.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@
 # Use the official Rust image as the base image
 FROM rust:latest
 ARG ZKP2P_BRANCH_NAME=develop
-ARG ZKP2P_VERSION=v0.0.10
-ARG PROVER_API_BRANCH_NAME=sachin/c-witness-gen
+ARG ZKP2P_VERSION=v0.1.0
+ARG PROVER_API_BRANCH_NAME=sachin/v0.1.0
 
 # Update the package list and install necessary dependencies
 RUN apt-get update && \

--- a/api.py
+++ b/api.py
@@ -273,10 +273,10 @@ print("merged crednetials", merged_credentials)
 # ----------------- MODAL -----------------
 
 image = modal.Image.from_registry(
-    "0xsachink/zkp2p:modal-c-0.0.10-v4", 
+    "0xsachink/zkp2p:modal-0.1.0", 
     add_python="3.11"
 ).pip_install_from_requirements("requirements.txt")
-stub = modal.Stub(name="zkp2p-c-v0.0.10", image=image)
+stub = modal.Stub(name="zkp2p-v0.1.0", image=image)
 stub['credentials_secret'] = modal.Secret.from_dict(merged_credentials)
 
 
@@ -304,7 +304,7 @@ def pull_and_prove_email(s3_url: str, email_type: str, nonce: str, intent_hash: 
 
 # ----------------- API -----------------
 
-@stub.function(cpu=48, memory=8000, secret=stub['credentials_secret'])
+@stub.function(cpu=48, memory=16000, secret=stub['credentials_secret'])
 @modal.web_endpoint(method="POST")
 def genproof_email(email_data: Dict):
 


### PR DESCRIPTION
## Description

New Endpoint: https://zkp2p--zkp2p-v0-1-0-genproof-email.modal.run

## Checklist

- [ ] Generate non-chunked keys and upload them to s3. [Used trusted setup keys instead]
- [x] Update these args in Dockerfile
  - [x] ARG ZKP2P_BRANCH_NAME=xxxxxx
  - [x] ARG ZKP2P_VERSION=xxxxxx
  - [x] ARG PROVER_API_BRANCH_NAME=xxxxxx
- [x] Commit the changes in prover-api
- [x] Build the docker file image on an AWS machine.
  - `sudo docker build -t 0xsachink/zkp2p:modal-0.0.x .`
- [x] Publish the docker image file to dockerhub.
  - `sudo docker push 0xsachink/zkp2p:modal-0.0.x`
- [x] Update the docker file version in prover/api.py. Also, increment the version in the stub name.
- [x] Serve the app using modal serve app.py.
- [x] Update the MODAL ENDPOINT link in the .env
- [x] Run python api.py to test the proof generation works!
- [x] Deploy the app using modal deploy app.py and paste the link above.
- [x] Commit the changes and open the PR for review
