### PR TITLE
Update venmo and hdfc to 2.4

### DIFF
--- a/src/venmo/Dockerfile
+++ b/src/venmo/Dockerfile
@@ -32,8 +32,8 @@
 # Use the official Rust image as the base image
 FROM rust:latest
 ARG ZKP2P_BRANCH_NAME=develop
-ARG ZKP2P_VERSION=v2.5/v0.2.0
-ARG PROVER_API_BRANCH_NAME=sachin/upi
+ARG ZKP2P_VERSION=v2.5/v0.2.4
+ARG PROVER_API_BRANCH_NAME=sachin/update-to-2.4
 ARG PAYMENT_TYPE=venmo
 ARG PAYMENT_ROOT_DIR=/root/zk-p2p/circuits-circom/circuits/${PAYMENT_TYPE}
 ARG BUILD_DIR=${PAYMENT_ROOT_DIR}/build


### PR DESCRIPTION
## Description

Please include a summary of change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
New Endpoint: https://zkp2p--zkp2p-v0-0-x-genproof-email.modal.run

## Checklist

- [ ] Generate non-chunked keys and upload them to s3.
- [ ] Update these args in Dockerfile
  - [ ] ARG ZKP2P_BRANCH_NAME=xxxxxx
  - [ ] ARG ZKP2P_VERSION=xxxxxx
  - [ ] ARG PROVER_API_BRANCH_NAME=xxxxxx
- [ ] Commit the changes in prover-api
- [ ] Build the docker file image on an AWS machine.
  - `sudo docker build -t 0xsachink/zkp2p:modal-0.0.x .`
- [ ] Publish the docker image file to dockerhub.
  - `sudo docker push 0xsachink/zkp2p:modal-0.0.x`
- [ ] Update the docker file version in prover/api.py. Also, increment the version in the stub name.
- [ ] Serve the app using modal serve app.py.
- [ ] Update the MODAL ENDPOINT link in the .env
- [ ] Run python api.py to test the proof generation works!
- [ ] Deploy the app using modal deploy app.py and paste the link above.
- [ ] Commit the changes and open the PR for review
